### PR TITLE
Relax `rainbow` dependecy requirements to allow 2.x and 3.x

### DIFF
--- a/lib/samovar/version.rb
+++ b/lib/samovar/version.rb
@@ -1,15 +1,15 @@
 # Copyright, 2016, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module Samovar
-	VERSION = "1.9.0"
+	VERSION = "1.9.1"
 end

--- a/samovar.gemspec
+++ b/samovar.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
 	spec.executables   = spec.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
 	spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
 	spec.require_paths = ["lib"]
-	
+
 	spec.add_dependency "mapping", "~> 1.0"
-	spec.add_dependency "rainbow", "~> 2.0"
+	spec.add_dependency "rainbow", ">= 2.0", "< 4.0"
 
 	spec.add_development_dependency "bundler", "~> 1.11"
 	spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
closes #1