### PR TITLE
Add support for multi flags

### DIFF
--- a/lib/samovar/option.rb
+++ b/lib/samovar/option.rb
@@ -7,7 +7,7 @@ require_relative 'flags'
 
 module Samovar
 	class Option
-		def initialize(flags, description, key: nil, default: nil, value: nil, type: nil, required: false, &block)
+		def initialize(flags, description, key: nil, default: nil, value: nil, type: nil, required: false, multi: false, &block)
 			@flags = Flags.new(flags)
 			@description = description
 			
@@ -26,6 +26,7 @@ module Samovar
 			@type = type
 			@required = required
 			@block = block
+			@multi = multi
 		end
 		
 		attr :flags
@@ -38,6 +39,7 @@ module Samovar
 		attr :type
 		attr :required
 		attr :block
+		attr :multi
 		
 		def coerce_type(result)
 			if @type == Integer
@@ -60,6 +62,10 @@ module Samovar
 			
 			if @block
 				result = @block.call(result)
+			end
+			
+			if multi
+				result = Array(result)
 			end
 			
 			return result
@@ -87,6 +93,13 @@ module Samovar
 			else
 				[@flags, @description]
 			end
+		end
+		
+		def join_results(existing_result, new_result)
+			return new_result if existing_result.nil?
+			return new_result unless multi
+			
+			existing_result + new_result
 		end
 	end
 end

--- a/lib/samovar/options.rb
+++ b/lib/samovar/options.rb
@@ -91,7 +91,7 @@ module Samovar
 			
 			while option = @keyed[input.first]
 				if result = option.parse(input)
-					values[option.key] = result
+					values[option.key] = option.join_results(values[option.key], result)
 				end
 			end
 			

--- a/readme.md
+++ b/readme.md
@@ -81,6 +81,7 @@ class Application < Samovar::Command
 		option '--things <a,b,c>', "A list of things" do |value|
 			value.split(/\s*,\s*/)
 		end
+		option '--multi <value>', "Pass this flag multiple times", multi: true
 	end
 end
 
@@ -95,6 +96,9 @@ application.options[:flag] # true
 
 application = Application.new(['--things', 'x,y,z'])
 application.options[:things] # ['x', 'y', 'z']
+
+application = Applicaiton.new(['--multi', 'v1', '--multi', 'v2'])
+application.options[:multi] # ['v1', 'v2']
 ```
 
 ### Nested Commands

--- a/test/samovar/options.rb
+++ b/test/samovar/options.rb
@@ -10,6 +10,8 @@ describe Samovar::Options do
 			option '-y <value>', "The y factor"
 			
 			option '--symbol <value>', "A symbol", type: Symbol
+			option '--multi <value>', "You can pass multiple values of this flag", multi: true
+			option '--multinum <value>', "Multiple numbers", type: Integer, multi: true
 		end
 	end
 	
@@ -31,5 +33,20 @@ describe Samovar::Options do
 	it "converts to symbol" do
 		values = options.parse(['--symbol', 'thing'], {})
 		expect(values[:symbol]).to be == :thing
+	end
+	
+	it 'picks the last value of an argument by default' do
+		values = options.parse(['--symbol', 'thing1', '--symbol', 'thing2'], {})
+		expect(values[:symbol]).to be == :thing2
+	end
+	
+	it 'appends arguments when multi is set' do
+		values = options.parse(['--multi', 'thing1', '--multi', 'thing2'], {})
+		expect(values[:multi]).to be == ['thing1', 'thing2']
+	end
+	
+	it 'can handle type coersions with multi' do
+		values = options.parse(['--multinum', '1', '--multinum', '8'])
+		expect(values[:multinum]).to be == [1, 8]
 	end
 end


### PR DESCRIPTION
Sometimes, it's nice to be able to handle multiple values for a flag. This commit adds a multi: argument to `option`, which, if provided, will cause multiple values of the same flag to be concatenated rather than last-one-wins.