### PR TITLE
Add support for flags provided with equal signs

### DIFF
--- a/lib/samovar/flags.rb
+++ b/lib/samovar/flags.rb
@@ -190,6 +190,9 @@ module Samovar
 					input.shift
 					return key
 				end
+			elsif prefix?(input.first.split("=").first)
+				flag, value = input.shift(1).first.split("=")
+				return value
 			end
 		end
 	end

--- a/lib/samovar/options.rb
+++ b/lib/samovar/options.rb
@@ -144,15 +144,15 @@ module Samovar
 		# @returns [Hash] The parsed option values.
 		def parse(input, parent = nil, default = nil)
 			values = (default || @defaults).dup
-			
-			while option = @keyed[input.first]
+
+			while option = @keyed[input.first] || @keyed[input.first&.split("=")&.first]
 				# prefix = input.first
 				result = option.parse(input)
 				if result != nil
 					values[option.key] = result
 				end
 			end
-			
+
 			# Validate required options
 			@ordered.each do |option|
 				if option.required && !values.key?(option.key)
@@ -161,7 +161,9 @@ module Samovar
 			end
 			
 			return values
-		end		# Generate a string representation for usage output.
+		end
+
+		# Generate a string representation for usage output.
 		# 
 		# @returns [String] The usage string.
 		def to_s


### PR DESCRIPTION
I'm working on a migration of the CLI in the Bridgetown web framework from Thor to Samovar. One of the blockers we identified is wanting to continue supporting flags written out in a key=value syntax. So for example:

```
command --myflag abc
command --myflag=abc
```

should be handled identically, which is what this PR solves. Let me know what you think about this approach! (Also I just realized I should write tests, if you're interested in the future.) Thanks.