### PR TITLE
Fix CI dependency resolution and modernise workflows

### DIFF
--- a/.github/workflows/documentation-coverage.yaml
+++ b/.github/workflows/documentation-coverage.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: ruby/setup-ruby@v1
       with:
@@ -39,7 +39,7 @@ jobs:
       run: bundle exec bake utopia:project:static --force no
     
     - name: Upload documentation artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v5
       with:
         path: docs
   
@@ -54,4 +54,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/rubocop.yaml
+++ b/.github/workflows/rubocop.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,13 +17,12 @@ jobs:
       matrix:
         os:
           - ubuntu
-          - macos
-        
+
         ruby:
           - ruby
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}
@@ -33,7 +32,7 @@ jobs:
       timeout-minutes: 5
       run: bundle exec bake test
     
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         include-hidden-files: true
         if-no-files-found: error
@@ -45,13 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ruby
         bundler-cache: true
     
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
     
     - name: Validate coverage
       timeout-minutes: 5

--- a/.github/workflows/test-external.yaml
+++ b/.github/workflows/test-external.yaml
@@ -17,12 +17,11 @@ jobs:
           - macos
         
         ruby:
-          - "3.2"
           - "3.3"
           - "3.4"
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -36,7 +36,7 @@ jobs:
             experimental: true
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{matrix.ruby}}

--- a/gems.rb
+++ b/gems.rb
@@ -20,7 +20,9 @@ end
 group :test do
 	gem "covered"
 	gem "sus"
-	gem "decode"
+	# `decode` depends on `rbs`, whose native extension fails to build on non-MRI
+	# runtimes (e.g. JRuby). It's only used for documentation coverage, which runs on MRI.
+	gem "decode", platforms: :mri
 	
 	gem "rubocop"
 	gem "rubocop-md"


### PR DESCRIPTION
Restrict `decode` to MRI platforms. It transitively depends on `rbs`, whose native extension fails to build on JRuby, breaking `bundle install` before any test runs. `decode` is only used for documentation coverage, which runs on MRI, so gating it to MRI is safe.

Drop Ruby 3.2 from the external test matrix. `bake test:external` clones the upstream `bake` repository, which now requires Ruby >= 3.3, so the 3.2 entry failed at dependency resolution. samovar itself still supports and is tested on 3.2 via the Test workflow.

Run test coverage on a single environment (ubuntu, latest Ruby). samovar has no version- or platform-conditional code, so coverage is identical across environments; the extra OS only added a job and an artifact without changing the validated result.

Bump GitHub Actions to their latest major versions
- `actions/checkout` v4 → v6
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

These run on Node 24, ahead of the [Node 20 runner deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on June 16th.