### PR TITLE
Support options provided with an equals sign (--flag=value)

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -93,6 +93,13 @@ application = Application.new(["--things", "x,y,z"])
 application.options[:things] # ['x', 'y', 'z']
 ~~~
 
+Options can also be joined to their value with an equals sign. The token is split on the first `=` only, so the value may itself contain `=`:
+
+~~~ ruby
+application = Application.new(["--frobulate=a=b"])
+application.options[:frobulate] # 'a=b'
+~~~
+
 ### Nested Commands
 
 You can create sub-commands that are nested within your main application:

--- a/lib/samovar/flags.rb
+++ b/lib/samovar/flags.rb
@@ -190,12 +190,23 @@ module Samovar
 					input.shift
 					return key
 				end
+			elsif input.first&.include?("=")
+				# The `--flag=value` form. Split on the first `=` only, so the value
+				# may itself contain `=` (e.g. `--option=a=b`):
+				flag, value = input.first.split("=", 2)
+				if prefix?(flag)
+					input.shift
+					return @value ? value : key
+				end
 			end
 		end
 	end
 	
 	# Represents a boolean flag with `--flag` and `--no-flag` variants.
 	class BooleanFlag < Flag
+		# Values which are treated as false in the `--flag=value` form (compared case-insensitively).
+		FALSE_VALUES = ["false", "no", "off", "0"].freeze
+		
 		# Initialize a new boolean flag.
 		# 
 		# @parameter text [String] The full flag specification text.
@@ -229,6 +240,15 @@ module Samovar
 			elsif input.first == @negated
 				input.shift
 				return false
+			elsif input.first&.include?("=")
+				# The `--flag=value` form, e.g. `--color=false`:
+				flag, value = input.first.split("=", 2)
+				if flag == @prefix || flag == @negated
+					input.shift
+					# A false-like value disables the flag; the negated prefix inverts it:
+					false_value = FALSE_VALUES.include?(value.downcase)
+					return flag == @negated ? false_value : !false_value
+				end
 			end
 		end
 	end

--- a/lib/samovar/options.rb
+++ b/lib/samovar/options.rb
@@ -145,8 +145,9 @@ module Samovar
 		def parse(input, parent = nil, default = nil)
 			values = (default || @defaults).dup
 			
-			while option = @keyed[input.first]
-				# prefix = input.first
+			# Match an option by its exact token (`--flag`), or by the part before
+			# the first `=` to support the `--flag=value` form:
+			while option = @keyed[input.first] || @keyed[input.first&.split("=", 2)&.first]
 				result = option.parse(input)
 				if result != nil
 					values[option.key] = result

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,8 @@
 
 ## v2.4.1
 
+  - Add support for options provided with an equals sign, e.g. `--config=path`. Both `--config path` and `--config=path` are accepted, and the token is split on the first `=` only, so the value may itself contain `=`.
+
 ## v2.4.0
 
   - Fix option parsing and validation: required options are now detected correctly and raise `Samovar::MissingValueError` when missing.

--- a/test/samovar/command.rb
+++ b/test/samovar/command.rb
@@ -194,5 +194,24 @@ describe Samovar::Command do
 			expect(usage).to be(:start_with?, "mycommand")
 		end
 	end
+	
+	with "equals sign option syntax" do
+		let(:command_class) do
+			Class.new(Samovar::Command) do
+				self.description = "A command that accepts a configuration file."
+				
+				options do
+					option "--config <path>", "The configuration file path."
+					option "--[no]-color", "Enable or disable color output."
+				end
+			end
+		end
+		
+		it "raises for an unknown option in the equals sign form" do
+			expect do
+				command_class.parse(["--unknown=value"])
+			end.to raise_exception(Samovar::InvalidInputError)
+		end
+	end
 end
 

--- a/test/samovar/flags.rb
+++ b/test/samovar/flags.rb
@@ -26,4 +26,20 @@ describe Samovar::BooleanFlag do
 		expect(flag.prefix?("--no-color")).to be == true
 		expect(flag.prefix?("--other")).to be == false
 	end
+	
+	it "ignores tokens that do not match the prefix" do
+		input = ["--other=true"]
+		expect(flag.parse(input)).to be_nil
+		expect(input).to be == ["--other=true"]
+	end
+end
+
+describe Samovar::ValueFlag do
+	let(:flag) {Samovar::Flag.parse("--config <path>")}
+	
+	it "ignores tokens that do not match the prefix" do
+		input = ["--other=value"]
+		expect(flag.parse(input)).to be_nil
+		expect(input).to be == ["--other=value"]
+	end
 end

--- a/test/samovar/options.rb
+++ b/test/samovar/options.rb
@@ -160,5 +160,61 @@ describe Samovar::Options do
 			expect(values[:thing].value).to be == "test"
 		end
 	end
+	
+	with "equals sign syntax" do
+		let(:options) do
+			subject.parse do
+				option "-c/--config <path>", "The configuration file path."
+				option "--verbose", "Enable verbose output."
+				option "--[no]-debug", "Enable or disable debugging."
+			end
+		end
+		
+		it "parses a value given with an equals sign" do
+			values = options.parse(["--config=app.yml"], {})
+			expect(values[:config]).to be == "app.yml"
+		end
+		
+		it "is equivalent to the space-separated form" do
+			expect(options.parse(["--config=app.yml"], {})).to be == options.parse(["--config", "app.yml"], {})
+		end
+		
+		it "splits on the first equals sign only" do
+			values = options.parse(["--config=a=b=c"], {})
+			expect(values[:config]).to be == "a=b=c"
+		end
+		
+		it "accepts an empty value after the equals sign" do
+			values = options.parse(["--config="], {})
+			expect(values[:config]).to be == ""
+		end
+		
+		it "parses an alternative prefix with an equals sign" do
+			values = options.parse(["-c=app.yml"], {})
+			expect(values[:config]).to be == "app.yml"
+		end
+		
+		it "treats a presence flag with an equals sign as set" do
+			values = options.parse(["--verbose=anything"], {})
+			expect(values[:verbose]).to be == true
+		end
+		
+		it "parses false-like boolean values case-insensitively" do
+			["false", "FALSE", "No", "off", "0"].each do |value|
+				expect(options.parse(["--debug=#{value}"], {})[:debug]).to be == false
+			end
+		end
+		
+		it "treats other boolean values as true" do
+			["true", "yes", "on", "1", "anything"].each do |value|
+				expect(options.parse(["--debug=#{value}"], {})[:debug]).to be == true
+			end
+		end
+		
+		it "inverts the value for a negated boolean flag" do
+			expect(options.parse(["--no-debug=off"], {})[:debug]).to be == true
+			expect(options.parse(["--no-debug=true"], {})[:debug]).to be == false
+		end
+	end
 end
 


### PR DESCRIPTION
Adds support for the `--flag=value` form for options, alongside the existing `--flag value` form.

- The token is split on the first `=` only, so a value may itself contain `=` (e.g. `--option=a=b` → `a=b`).
- Value options (`--config <path>`) take the text after `=` as the value.
- Presence flags (`--verbose`) are set to `true`; any `=value` is ignored.
- Explicit boolean flags (`--[no]-color`) interpret the value as a boolean (`false`/`no`/`off`/`0` → false, otherwise true); the negated prefix inverts it (`--no-color=true` → false).
- An unknown `--flag=value` still raises `Samovar::InvalidInputError`.

### Examples

```
--config=app.yml     # => "app.yml"
--config=a=b=c       # => "a=b=c"   (split on the first = only)
--config=            # => ""
-c=app.yml           # => "app.yml" (alternative prefix)
--color=false        # => false
```