### PR TITLE
Improve test coverage

### DIFF
--- a/test/samovar/boolean_flag.rb
+++ b/test/samovar/boolean_flag.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "samovar/flags"
+
+describe Samovar::BooleanFlag do
+	let(:flag) {Samovar::Flag.parse("--[no]-color")}
+	
+	it "can check prefix" do
+		expect(flag.prefix?("--color")).to be == true
+		expect(flag.prefix?("--no-color")).to be == true
+		expect(flag.prefix?("--other")).to be == false
+	end
+end

--- a/test/samovar/completion.rb
+++ b/test/samovar/completion.rb
@@ -103,6 +103,12 @@ describe Samovar::Completion do
 		expect(values(result)).to be == ["json"]
 	end
 	
+	it "continues completion after consuming option values" do
+		result = complete(["--configuration", "development", ""])
+		
+		expect(values(result)).to be == ["--configuration", "-c", "--verbose", "-v", "leaf", "list"]
+	end
+	
 	it "requests native path completion for option values" do
 		result = complete(["leaf", "--output", "tmp/"])
 		suggestion = result.first
@@ -173,6 +179,24 @@ describe Samovar::Completion do
 		result = complete(["--no"])
 		
 		expect(values(result)).to be == ["--no-color"]
+	end
+	
+	it "uses default nested command for unmatched command words" do
+		result = complete(["unknown", ""])
+		
+		expect(values(result)).to be == ["extra-a", "extra-b"]
+	end
+	
+	it "returns collected suggestions for unmatched nested commands without default" do
+		nested = Samovar::Nested.new(:command, {"list" => CompletionList})
+		context = Samovar::Completion::Context.for(CompletionTop, ["unknown", ""])
+		collected = [
+			Samovar::Completion::Suggestion.new("--verbose", type: :option)
+		]
+		
+		result = nested.complete(["unknown"], context, collected)
+		
+		expect(values(result)).to be == ["--verbose"]
 	end
 	
 	it "prints completion results as TSV" do

--- a/test/samovar/flag.rb
+++ b/test/samovar/flag.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2026, by Samuel Williams.
+
+require "samovar/flags"
+
+describe Samovar::Flag do
+	let(:flag) {subject.new("--flag", "--flag", ["-f"])}
+	
+	it "can check alternatives" do
+		expect(flag.prefix?("-f")).to be == true
+	end
+end

--- a/test/samovar/flags.rb
+++ b/test/samovar/flags.rb
@@ -16,14 +16,10 @@ describe Samovar::Flags do
 		result = flags.parse(["--other"])
 		expect(result).to be_nil
 	end
-end
-
-describe Samovar::BooleanFlag do
-	let(:flag) {Samovar::Flag.parse("--[no]-color")}
 	
-	it "can check prefix" do
-		expect(flag.prefix?("--color")).to be == true
-		expect(flag.prefix?("--no-color")).to be == true
-		expect(flag.prefix?("--other")).to be == false
+	it "matches flag alternatives" do
+		flag = flags.first
+		
+		expect(flag.prefix?("-f")).to be == true
 	end
 end

--- a/test/samovar/many.rb
+++ b/test/samovar/many.rb
@@ -62,6 +62,16 @@ describe Samovar::Many do
 			expect(many_no_stop.parse(all_input)).to be == ["1", "2", "3", "--also"]
 			expect(all_input).to be(:empty?)
 		end
+		
+		it "clears previous input before completing" do
+			many_no_stop = subject.new(:items, "all items", stop: nil, completions: ["one", "two"])
+			context = Samovar::Completion::Context.for(Samovar::Command, ["previous", "t"])
+			input = ["previous"]
+			
+			result = many_no_stop.complete(input, context, [])
+			
+			expect(input).to be(:empty?)
+			expect(result.collect(&:value)).to be == ["two"]
+		end
 	end
 end
-

--- a/test/samovar/one.rb
+++ b/test/samovar/one.rb
@@ -32,6 +32,15 @@ describe Samovar::One do
 		expect(input).to be == ["3", "4"]
 	end
 	
+	it "completes with no suggestions if input does not match" do
+		one = subject.new(:thing, "a thing", pattern: /^valid$/, completions: ["valid"])
+		context = Samovar::Completion::Context.for(Samovar::Command, ["invalid", ""])
+		
+		result = one.complete(["invalid"], context, [])
+		
+		expect(result).to be(:empty?)
+	end
+	
 	with "required field" do
 		let(:required_one) {subject.new(:thing, "a thing", required: true)}
 		
@@ -54,4 +63,3 @@ describe Samovar::One do
 		end
 	end
 end
-

--- a/test/samovar/options.rb
+++ b/test/samovar/options.rb
@@ -20,6 +20,16 @@ describe Samovar::Options do
 		expect(values).to be == {x: 2}
 	end
 	
+	it "lists option completions" do
+		expect(options.completions).to be == ["-x", "-y", "--symbol"]
+	end
+	
+	it "knows whether an option consumes a value" do
+		option = options.option_for("-x")
+		
+		expect(option).to be(:value?)
+	end
+	
 	it "should resolve callable defaults" do
 		count = 0
 		

--- a/test/samovar/output/header.rb
+++ b/test/samovar/output/header.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require "samovar"
+require "samovar/output/header"
+
+describe Samovar::Output::Header do
+	let(:command_class) do
+		Class.new(Samovar::Command) do
+			self.description = "Test command"
+			
+			options do
+				option "--help", "Show help"
+			end
+		end
+	end
+	
+	it "can align header" do
+		header = Samovar::Output::Header.new("test", command_class)
+		result = header.align(nil)
+		
+		expect(result).to be(:include?, "test")
+	end
+end

--- a/test/samovar/output/rows.rb
+++ b/test/samovar/output/rows.rb
@@ -5,7 +5,6 @@
 
 require "samovar"
 require "samovar/output/rows"
-require "samovar/output/header"
 
 describe Samovar::Output::Rows do
 	let(:rows) {subject.new}
@@ -23,24 +22,5 @@ describe Samovar::Output::Rows do
 		rows << Samovar::Option.new("-x", "X value")
 		rows << Samovar::Option.new("-y", "Y value")
 		expect(rows.last).not.to be_nil
-	end
-end
-
-describe Samovar::Output::Header do
-	let(:command_class) do
-		Class.new(Samovar::Command) do
-			self.description = "Test command"
-			
-			options do
-				option "--help", "Show help"
-			end
-		end
-	end
-	
-	it "can align header" do
-		header = Samovar::Output::Header.new("test", command_class)
-		result = header.align(nil)
-		
-		expect(result).to be(:include?, "test")
 	end
 end


### PR DESCRIPTION
## Summary
- add focused tests for parser and completion edge cases
- split flag-related specs into per-class files
- split output specs to mirror the output lib layout

## Verification
- bundle exec sus
- rm -f .covered.db && COVERAGE=BriefSummary bundle exec sus

Coverage: 24 files checked; 800/800 lines executed; 100.0% covered.