### PR TITLE
Handle empty completion arguments

### DIFF
--- a/lib/samovar/completion/context.rb
+++ b/lib/samovar/completion/context.rb
@@ -16,10 +16,13 @@ module Samovar
 			# @parameter environment [Hash] The environment for completion callbacks.
 			# @returns [Context] The completion context.
 			def self.for(command_class, arguments, environment: ENV)
+				arguments = arguments.dup
+				current = arguments.pop || ""
+				
 				return self.new(
 					command_class.table.merged,
 					arguments,
-					arguments.last || "",
+					current,
 					environment: environment,
 				)
 			end
@@ -27,7 +30,7 @@ module Samovar
 			# Initialize a new completion context.
 			#
 			# @parameter table [Table] The command table to complete.
-			# @parameter arguments [Array(String)] The truncated command-line arguments.
+			# @parameter arguments [Array(String)] The completed words before the current token.
 			# @parameter current [String] The token being completed.
 			# @parameter row [Object | Nil] The parser row whose value is being completed.
 			# @parameter environment [Hash] The environment for completion callbacks.
@@ -42,7 +45,7 @@ module Samovar
 			# @attribute [Table] The command table to complete.
 			attr :table
 			
-			# @attribute [Array(String)] The truncated command-line arguments.
+			# @attribute [Array(String)] The completed words before the current token.
 			attr :arguments
 			
 			# @attribute [String] The token being completed.
@@ -68,18 +71,11 @@ module Samovar
 				)
 			end
 			
-			# The completed words before the current token.
-			#
-			# @returns [Array(String)] The arguments before the token being completed.
-			def words
-				@arguments.take(@arguments.size - 1)
-			end
-			
 			# Complete the current command class.
 			#
 			# @returns [Result] The completion result.
 			def complete
-				complete_rows(@table, words)
+				complete_rows(@table, @arguments.dup)
 			end
 			
 			# Complete the given command class with completed words.

--- a/lib/samovar/split.rb
+++ b/lib/samovar/split.rb
@@ -111,7 +111,7 @@ module Samovar
 							input.first,
 							description: "Delegate completion",
 							type: :delegate,
-							index: context.words.index(@marker) + 1,
+							index: context.arguments.index(@marker) + 1,
 						),
 					])
 				end

--- a/test/samovar/completion.rb
+++ b/test/samovar/completion.rb
@@ -284,4 +284,24 @@ describe Samovar::Completion do
 		expect(output.string).to be(:include?, "command\tleaf\tLeaf command.\n")
 		expect(output.string).to be(:include?, "option\t--verbose\tEnable verbose output.\n")
 	end
+	
+	it "splits completed arguments from the current token" do
+		arguments = ["leaf", "--ver"]
+		
+		context = Samovar::Completion::Context.for(CompletionTop, arguments)
+		
+		expect(context.arguments).to be == ["leaf"]
+		expect(context.current).to be == "--ver"
+		expect(arguments).to be == ["leaf", "--ver"]
+	end
+	
+	it "completes with no arguments" do
+		output = StringIO.new
+		
+		result = CompletionTop.complete([], output: output)
+		
+		expect(values(result)).to be(:include?, "leaf")
+		expect(output.string).to be(:include?, "command\tleaf\tLeaf command.\n")
+		expect(output.string).to be(:include?, "option\t--verbose\tEnable verbose output.\n")
+	end
 end


### PR DESCRIPTION
## Summary

- Handle empty completion argument arrays as no completed words.
- Add a regression test for completing a command with no arguments.

## Tests

- `BUNDLE_GEMFILE=gems.rb bundle exec sus`
- `BUNDLE_GEMFILE=gems.rb bundle exec rubocop`
- `BUNDLE_GEMFILE=gems.rb COVERAGE=PartialSummary bundle exec bake decode:index:coverage lib`
